### PR TITLE
Print heredocs consistently with lineSuffix(newline+contents+ending) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --cache .",
     "print": "prettier --plugin=.",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --cache .",
     "print": "prettier --plugin=.",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "repository": {
     "type": "git",

--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -5,7 +5,6 @@ const {
   indent,
   join,
   line,
-  literalline,
   softline
 } = require("../prettier");
 
@@ -114,40 +113,15 @@ module.exports = {
     const elementDocs = path.call(print, "body", 0);
     const elements = getElements(path.getValue().body[0], ["body", 0]);
 
-    // We need to manually loop through the elements in the array in order to
-    // take care of heredocs printing (their commas go after the opening, as
-    // opposed to at the end).
-    elements.forEach(({ element, elementPath }, index) => {
+    elements.forEach((_, index) => {
       const isInner = index !== elements.length - 1;
 
-      const isStraightHeredoc = element.type === "heredoc";
-      const isSquigglyHeredoc =
-        element.type === "string_literal" && element.body[0].type === "heredoc";
+      normalDocs.push(elementDocs[index]);
 
-      if (isStraightHeredoc || isSquigglyHeredoc) {
-        const heredocNode = isStraightHeredoc ? element : element.body[0];
-        const heredocPath = [print].concat(elementPath);
-
-        if (isSquigglyHeredoc) {
-          heredocPath.push("body", 0);
-        }
-
-        normalDocs.push(
-          heredocNode.beging,
-          isInner || addTrailingCommas ? "," : "",
-          literalline,
-          concat(path.map.apply(path, heredocPath.concat("body"))),
-          heredocNode.ending,
-          isInner ? line : ""
-        );
-      } else {
-        normalDocs.push(elementDocs[index]);
-
-        if (isInner) {
-          normalDocs.push(concat([",", line]));
-        } else if (addTrailingCommas) {
-          normalDocs.push(ifBreak(",", ""));
-        }
+      if (isInner) {
+        normalDocs.push(concat([",", line]));
+      } else if (addTrailingCommas) {
+        normalDocs.push(ifBreak(",", ""));
       }
     });
 

--- a/src/nodes/commands.js
+++ b/src/nodes/commands.js
@@ -1,5 +1,5 @@
 const { align, concat, group, ifBreak, join, line } = require("../prettier");
-const { docLength, makeArgs, makeCall } = require("../utils");
+const { docLength, makeCall } = require("../utils");
 
 const hasDef = (node) =>
   node.body[1].type === "args_add_block" &&
@@ -26,29 +26,18 @@ const skipArgsAlign = (path) =>
 module.exports = {
   command: (path, opts, print) => {
     const command = path.call(print, "body", 0);
-    const { args, heredocs } = makeArgs(path, opts, print, 1);
 
-    if (heredocs.length > 1) {
-      return concat([command, " ", join(", ", args)].concat(heredocs));
-    }
-
-    const joinedArgs = join(concat([",", line]), args);
+    const joinedArgs = join(concat([",", line]), path.call(print, "body", 1));
     const breakArgs = hasDef(path.getValue())
       ? joinedArgs
       : align(command.length + 1, joinedArgs);
 
-    const commandDoc = group(
+    return group(
       ifBreak(
         concat([command, " ", breakArgs]),
         concat([command, " ", joinedArgs])
       )
     );
-
-    if (heredocs.length === 1) {
-      return group(concat([commandDoc].concat(heredocs)));
-    }
-
-    return commandDoc;
   },
   command_call: (path, opts, print) => {
     const parts = [
@@ -62,25 +51,14 @@ module.exports = {
     }
 
     parts.push(" ");
-    const { args, heredocs } = makeArgs(path, opts, print, 3);
 
-    if (heredocs.length > 1) {
-      return concat(parts.concat([join(", ", args)]).concat(heredocs));
-    }
-
-    const joinedArgs = join(concat([",", line]), args);
+    const joinedArgs = join(concat([",", line]), path.call(print, "body", 3));
     const breakArgs = skipArgsAlign(path)
       ? joinedArgs
       : align(docLength(concat(parts)), joinedArgs);
 
-    const commandDoc = group(
+    return group(
       ifBreak(concat(parts.concat(breakArgs)), concat(parts.concat(joinedArgs)))
     );
-
-    if (heredocs.length === 1) {
-      return group(concat([commandDoc].concat(heredocs)));
-    }
-
-    return commandDoc;
   }
 };

--- a/src/nodes/hashes.js
+++ b/src/nodes/hashes.js
@@ -1,12 +1,4 @@
-const {
-  concat,
-  group,
-  ifBreak,
-  indent,
-  join,
-  line,
-  literalline
-} = require("../prettier");
+const { concat, group, ifBreak, indent, join, line } = require("../prettier");
 const { nodeDive, prefix, skipAssignIndent } = require("../utils");
 
 // When attempting to convert a hash rocket into a hash label, you need to take
@@ -77,43 +69,13 @@ module.exports = {
 
     assocNodes.forEach((assocNode, index) => {
       const isInner = index !== assocNodes.length - 1;
-      const valueNode = assocNode.body[1];
 
-      const isStraightHeredoc = valueNode && valueNode.type === "heredoc";
-      const isSquigglyHeredoc =
-        valueNode &&
-        valueNode.type === "string_literal" &&
-        valueNode.body[0].type === "heredoc";
+      assocDocs.push(path.call(print, "body", 0, index));
 
-      if (isStraightHeredoc || isSquigglyHeredoc) {
-        const heredocSteps = isStraightHeredoc
-          ? ["body", 1]
-          : ["body", 1, "body", 0];
-        const { beging, ending } = nodeDive(assocNode, heredocSteps);
-
-        assocDocs.push(
-          makeLabel(path, opts, print, ["body", 0, index, "body", 0]),
-          " ",
-          beging,
-          isInner || addTrailingCommas ? "," : "",
-          literalline,
-          concat(
-            path.map.apply(
-              path,
-              [print, "body", 0, index].concat(heredocSteps).concat("body")
-            )
-          ),
-          ending,
-          isInner ? line : ""
-        );
-      } else {
-        assocDocs.push(path.call(print, "body", 0, index));
-
-        if (isInner) {
-          assocDocs.push(concat([",", line]));
-        } else if (addTrailingCommas) {
-          assocDocs.push(ifBreak(",", ""));
-        }
+      if (isInner) {
+        assocDocs.push(concat([",", line]));
+      } else if (addTrailingCommas) {
+        assocDocs.push(ifBreak(",", ""));
       }
     });
 

--- a/src/nodes/strings.js
+++ b/src/nodes/strings.js
@@ -4,6 +4,7 @@ const {
   hardline,
   indent,
   literalline,
+  lineSuffix,
   softline,
   join
 } = require("../prettier");
@@ -103,7 +104,10 @@ module.exports = {
       return join(literalline, part.body.split("\n"));
     });
 
-    return concat([beging, literalline, concat(parts), ending]);
+    return concat([
+      beging,
+      lineSuffix(concat([literalline, concat(parts), ending]))
+    ]);
   },
   string: makeList,
   string_concat: (path, opts, print) =>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,4 @@
-const {
-  breakParent,
-  concat,
-  hardline,
-  lineSuffix,
-  literalline
-} = require("./prettier");
+const { breakParent, concat, hardline, lineSuffix } = require("./prettier");
 
 const concatBody = (path, opts, print) => concat(path.map(print, "body"));
 
@@ -51,45 +45,6 @@ const hasAncestor = (path, types) => {
 };
 
 const literal = (value) => () => value;
-
-const makeArgs = (path, opts, print, argsIndex) => {
-  let argNodes = path.getValue().body[argsIndex];
-  const argPattern = [print, "body", argsIndex, "body"];
-
-  if (argNodes.type === "args_add_block") {
-    [argNodes] = argNodes.body;
-    argPattern.push(0, "body");
-  }
-
-  const args = path.call(print, "body", argsIndex);
-  const heredocs = [];
-
-  argNodes.body.forEach((argNode, index) => {
-    let pattern;
-    let heredoc;
-
-    if (argNode.type === "heredoc") {
-      pattern = [index, "body"];
-      heredoc = argNode;
-    } else if (
-      argNode.type === "string_literal" &&
-      argNode.body[0].type === "heredoc"
-    ) {
-      pattern = [index, "body", 0, "body"];
-      [heredoc] = argNode.body;
-    } else {
-      return;
-    }
-
-    const content = path.map.apply(path, argPattern.slice().concat(pattern));
-    heredocs.push(
-      concat([literalline].concat(content).concat([heredoc.ending]))
-    );
-    args[index] = heredoc.beging;
-  });
-
-  return { args, heredocs };
-};
 
 const makeCall = (path, opts, print) => {
   const operation = path.getValue().body[1];
@@ -157,7 +112,6 @@ module.exports = {
   first,
   hasAncestor,
   literal,
-  makeArgs,
   makeCall,
   makeList,
   nodeDive,

--- a/test/js/args.test.js
+++ b/test/js/args.test.js
@@ -1,0 +1,335 @@
+const { ruby } = require("./utils");
+
+describe("args", () => {
+  describe("heredocs", () => {
+    test("#586 - long hash key after heredoc", () => {
+      const content = ruby(`
+        def foo(*); end
+
+        foo(
+          <<~FOO,
+            foo
+          FOO
+          named_argument_that_is_quite_long_so_it_doesnt_fit_on_one_line_with_the_heredoc: 'bar',
+        )
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          def foo(*); end
+
+          foo(
+            <<~FOO,
+              foo
+            FOO
+            named_argument_that_is_quite_long_so_it_doesnt_fit_on_one_line_with_the_heredoc:
+              'bar'
+          )
+        `)
+      );
+    });
+
+    test("#301 - heredoc arg w/ block", () => {
+      const content = ruby(`
+        puts(<<~TEXT
+          Hello
+        TEXT
+        ) { "sample block" }
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          puts(
+            <<~TEXT
+            Hello
+          TEXT
+          ) { 'sample block' }
+        `)
+      );
+    });
+
+    test("#301 - in an activerecord scope arg w/ chaining", () => {
+      const content = ruby(`
+        scope :late_for_checkin, -> {
+          select(
+            <<-EOS.squish
+              devices.*, (
+                SELECT device_readings.id
+                FROM device_readings
+                WHERE device_readings.device_id = devices.id
+                  AND device_readings.taken_at > DATE_SUB(NOW(), INTERVAL (frequency * 2) MINUTE)
+                LIMIT 1
+              ) AS reading_id
+            EOS
+          )
+            .data_push
+            .having("reading_id IS NULL")
+        }
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          scope :late_for_checkin,
+                lambda {
+                  select(
+                    <<-EOS.squish
+                devices.*, (
+                  SELECT device_readings.id
+                  FROM device_readings
+                  WHERE device_readings.device_id = devices.id
+                    AND device_readings.taken_at > DATE_SUB(NOW(), INTERVAL (frequency * 2) MINUTE)
+                  LIMIT 1
+                ) AS reading_id
+              EOS
+                  ).data_push.having('reading_id IS NULL')
+                }
+       `)
+      );
+    });
+
+    test("#586 - long breakable arg after heredoc literal", () => {
+      const content = ruby(`
+        p <<-BAR, ['value', 'value', 'value', 'value', 'value', 'value', 'value', 'value', 125484, 024024103]
+          text
+        BAR
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          p <<-BAR,
+            text
+          BAR
+            [
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              125_484,
+              0o24024103
+            ]
+        `)
+      );
+    });
+
+    test("#586 - call w/ short breakable arg after heredoc literal", () => {
+      const content = ruby(`
+        p(<<-BAR, ['value', 'value', 125484, 024024103])
+          text
+        BAR
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          p(
+            <<-BAR,
+            text
+          BAR
+            ['value', 'value', 125_484, 0o24024103]
+          )
+        `)
+      );
+    });
+
+    test("on calls", () => {
+      const content = ruby(`
+          call(1, 2, 3, <<-HERE) do
+           foo
+          HERE
+            puts 'more code'
+          end
+        `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          call(
+            1,
+            2,
+            3,
+            <<-HERE
+           foo
+          HERE
+          ) { puts 'more code' }
+        `)
+      );
+    });
+
+    test("on calls with trailing arguments", () => {
+      const content = ruby(`
+          call(1, <<-HERE, 2)
+            foo
+          HERE
+        `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          call(
+            1,
+            <<-HERE,
+            foo
+          HERE
+            2
+          )
+        `)
+      );
+    });
+
+    test("in parens args with trailing args after", () => {
+      const content = ruby(`
+          Foo.new(<<-ARG1, 'test2')
+            test1 line 1
+            test1 line 2
+          ARG1
+        `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          Foo.new(
+            <<-ARG1,
+            test1 line 1
+            test1 line 2
+          ARG1
+            'test2'
+          )
+        `)
+      );
+    });
+
+    test("in paren args with a call", () => {
+      const content = ruby(`
+        Foo.new(<<~ARG1.upcase.chomp, 'test2')
+          test1 line 1
+          test1 line 2
+        ARG1
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          Foo.new(
+            <<~ARG1.upcase.chomp,
+            test1 line 1
+            test1 line 2
+          ARG1
+            'test2'
+          )
+        `)
+      );
+    });
+
+    test("on calls with multiple", () => {
+      const content = ruby(`
+        call(1, 2, 3, <<-HERE, <<-THERE)
+          here
+        HERE
+          there
+        THERE
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          call(
+            1,
+            2,
+            3,
+            <<-HERE,
+            here
+          HERE
+            <<-THERE
+            there
+          THERE
+          )
+        `)
+      );
+    });
+
+    test("on commands", () => {
+      const content = ruby(`
+        command 1, 2, 3, <<-HERE
+          foo
+        HERE
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          command 1,
+                  2,
+                  3,
+                  <<-HERE
+            foo
+          HERE
+        `)
+      );
+    });
+
+    test("on commands with multiple", () => {
+      const content = ruby(`
+          command 1, 2, 3, <<-HERE, <<-THERE
+            here
+          HERE
+            there
+          THERE
+        `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+        command 1,
+                2,
+                3,
+                <<-HERE,
+          here
+        HERE
+                <<-THERE
+          there
+        THERE
+        `)
+      );
+    });
+
+    test("on command calls with trailing arg", () => {
+      const content = ruby(`
+        command.call 1, 2, 3, <<-HERE, 4
+          foo
+        HERE
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          command.call 1,
+                       2,
+                       3,
+                       <<-HERE,
+            foo
+          HERE
+                       4
+        `)
+      );
+    });
+
+    test("on command calls with multiple", () => {
+      const content = ruby(`
+        command.call 1, 2, 3, <<-HERE, <<-THERE
+          here
+        HERE
+            there
+        THERE
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          command.call 1,
+                       2,
+                       3,
+                       <<-HERE,
+            here
+          HERE
+                       <<-THERE
+              there
+          THERE
+        `)
+      );
+    });
+  });
+});

--- a/test/js/assign.test.js
+++ b/test/js/assign.test.js
@@ -4,6 +4,16 @@ describe("assign", () => {
   describe("single assignment", () => {
     test("basic", () => expect("a = 1").toMatchFormat());
 
+    test("heredoc", () => {
+      const content = ruby(`
+        text = <<-TEXT
+          abcd
+        TEXT
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
     test("multiline", () => {
       const content = ruby(`
         a =

--- a/test/js/calls.test.js
+++ b/test/js/calls.test.js
@@ -1,0 +1,99 @@
+const { ruby } = require("./utils");
+
+describe("calls", () => {
+  describe("heredocs", () => {
+    test("squiggly no indent", () => {
+      const content = ruby(`
+        foo = <<~TEXT.strip
+          bar
+        TEXT
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("squiggly indent", () => {
+      const content = ruby(`
+        foo = (<<~TEXT
+          bar
+        TEXT
+        ).strip
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          foo =
+            (
+              <<~TEXT
+            bar
+          TEXT
+            ).strip
+        `)
+      );
+    });
+
+    test("straight no indent", () => {
+      const content = ruby(`
+        foo = <<-TEXT.strip
+        bar
+        TEXT
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+  });
+
+  test("with a call and indented", () => {
+    const content = ruby(`
+      def foo
+        <<-HERE.strip
+          bar
+        HERE
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("with a method call", () => {
+    const content = ruby(`
+      <<-HERE.strip.chomp
+        This is a straight heredoc
+        with two method calls
+      HERE
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("with two calls and indented", () => {
+    const content = ruby(`
+      def foo
+        <<~HERE.strip.chomp
+          bar
+        HERE
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("with a long list of calls and line length", () => {
+    const content = ruby(`
+      <<~HERE.strip.chomp.split.concat(['one']).join.gsub(/one|two|three|four/, 'number').gsub('®', '').reverse
+        bar
+      HERE
+    `);
+
+    return expect(content).toChangeFormat(
+      ruby(`
+        <<~HERE.strip.chomp.split.concat(%w[one]).join.gsub(
+          bar
+        HERE
+          /one|two|three|four/,
+          'number'
+        ).gsub('®', '').reverse
+    `)
+    );
+  });
+});

--- a/test/js/strings.test.js
+++ b/test/js/strings.test.js
@@ -169,6 +169,17 @@ describe("strings", () => {
         return expect(content).toMatchFormat();
       });
 
+      // xstring_literal has no @backtick in the scanner events
+      test.skip("xstring", () => {
+        const content = ruby(`
+          <<-\`SHELL\`
+            ls
+          SHELL
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
       test("with interpolation", () => {
         const content = ruby(`
           <<-HERE
@@ -179,54 +190,6 @@ describe("strings", () => {
         `);
 
         return expect(content).toMatchFormat();
-      });
-
-      test("with a method call", () => {
-        const content = ruby(`
-          <<-HERE.strip.chomp
-            This is a straight heredoc
-            with two method calls
-          HERE
-        `);
-
-        return expect(content).toChangeFormat(
-          ruby(`
-            (
-            <<-HERE
-              This is a straight heredoc
-              with two method calls
-            HERE
-            ).strip.chomp
-          `)
-        );
-      });
-
-      test("#586", () => {
-        const content = ruby(`
-          p <<-BAR, ['value', 'value', 'value', 'value', 'value', 'value', 'value', 'value', 125484, 024024103]
-            text
-          BAR
-        `);
-
-        return expect(content).toChangeFormat(
-          ruby(`
-            p <<-BAR,
-              text
-            BAR
-            [
-              'value',
-              'value',
-              'value',
-              'value',
-              'value',
-              'value',
-              'value',
-              'value',
-              125_484,
-              0o24024103
-            ]
-          `)
-        );
       });
 
       test("on an assignment", () => {
@@ -263,18 +226,6 @@ describe("strings", () => {
             ${long}
             ${long}
           HERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("with a call and indented", () => {
-        const content = ruby(`
-          def foo
-            <<-HERE.strip
-              bar
-            HERE
-          end
         `);
 
         return expect(content).toMatchFormat();
@@ -324,160 +275,6 @@ describe("strings", () => {
               CHILD
           }
           PARENT
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("with two calls and indented", () => {
-        const content = ruby(`
-          def foo
-            <<~HERE.strip.chomp
-              bar
-            HERE
-          end
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-    });
-
-    describe("as an argument", () => {
-      test("on calls", () => {
-        const content = ruby(`
-          call(1, 2, 3, <<-HERE)
-            foo
-          HERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("on calls with trailing arguments", () => {
-        const content = ruby(`
-          call(1, <<-HERE, 2)
-            foo
-          HERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("in parens args with trailing args after", () => {
-        const content = ruby(`
-          Foo.new(<<-ARG1, 'test2')
-            test1 line 1
-            test1 line 2
-          ARG1
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("in paren args with a call", () => {
-        const content = ruby(`
-          Foo.new(<<~ARG1.upcase.chomp, 'test2')
-            test1 line 1
-            test1 line 2
-          ARG1
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("on calls with multiple", () => {
-        const content = ruby(`
-          call(1, 2, 3, <<-HERE, <<-THERE)
-            here
-          HERE
-            there
-          THERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("on commands", () => {
-        const content = ruby(`
-          command 1, 2, 3, <<-HERE
-            foo
-          HERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("on commands with multiple", () => {
-        const content = ruby(`
-          command 1, 2, 3, <<-HERE, <<-THERE
-            here
-          HERE
-            there
-          THERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("on command calls", () => {
-        const content = ruby(`
-          command.call 1, 2, 3, <<-HERE
-            foo
-          HERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("on command calls with multiple", () => {
-        const content = ruby(`
-          command.call 1, 2, 3, <<-HERE, <<-THERE
-            here
-          HERE
-            there
-          THERE
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-    });
-
-    describe("with a call attached", () => {
-      test("squiggly no indent", () => {
-        const content = ruby(`
-          foo = <<~TEXT.strip
-          bar
-          TEXT
-        `);
-
-        return expect(content).toMatchFormat();
-      });
-
-      test("squiggly indent", () => {
-        const content = ruby(`
-          foo = (<<~TEXT
-            bar
-          TEXT
-          ).strip
-        `);
-
-        return expect(content).toChangeFormat(
-          ruby(`
-            foo =
-              (
-                <<~TEXT
-              bar
-            TEXT
-              ).strip
-          `)
-        );
-      });
-
-      test("straight no indent", () => {
-        const content = ruby(`
-          foo = <<-TEXT.strip
-          bar
-          TEXT
         `);
 
         return expect(content).toMatchFormat();

--- a/test/rb/metadata_test.rb
+++ b/test/rb/metadata_test.rb
@@ -5,14 +5,16 @@ require_relative '../../src/ripper'
 
 class MetadataTest < Minitest::Test
   def test_BEGIN
-    assert_metadata :BEGIN, <<~SOURCE
+    assert_metadata :BEGIN,
+                    <<~SOURCE
       BEGIN {
       }
     SOURCE
   end
 
   def test_END
-    assert_metadata :END, <<~SOURCE
+    assert_metadata :END,
+                    <<~SOURCE
       END {
       }
     SOURCE
@@ -23,7 +25,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_array_args
-    assert_metadata :array, <<~SOURCE
+    assert_metadata :array,
+                    <<~SOURCE
       [
         foo,
         bar,
@@ -33,7 +36,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_array_args_add_star
-    assert_metadata :array, <<~SOURCE
+    assert_metadata :array,
+                    <<~SOURCE
       [
         foo,
         *bar,
@@ -43,7 +47,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_array_qwords
-    assert_metadata :array, <<~SOURCE
+    assert_metadata :array,
+                    <<~SOURCE
       %w[
         foo
         bar
@@ -141,7 +146,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_begin
-    assert_metadata :begin, <<~SOURCE
+    assert_metadata :begin,
+                    <<~SOURCE
       begin
         begin; end
       end
@@ -193,7 +199,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_case
-    assert_metadata :case, <<~SOURCE
+    assert_metadata :case,
+                    <<~SOURCE
       case foo
       when bar
         case baz
@@ -204,7 +211,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_class
-    assert_metadata :class, <<~SOURCE
+    assert_metadata :class,
+                    <<~SOURCE
       class Foo
         class Bar; end
       end
@@ -240,7 +248,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_def
-    assert_metadata :def, <<~SOURCE
+    assert_metadata :def,
+                    <<~SOURCE
       def foo
         def bar; end
       end
@@ -248,7 +257,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_defined
-    assert_metadata :defined, <<~SOURCE
+    assert_metadata :defined,
+                    <<~SOURCE
       defined?(
         Foo
       )
@@ -256,7 +266,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_defs
-    assert_metadata :defs, <<~SOURCE
+    assert_metadata :defs,
+                    <<~SOURCE
       def Object.foo
         def Object.bar; end
       end
@@ -358,7 +369,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_for
-    assert_metadata :for, <<~SOURCE
+    assert_metadata :for,
+                    <<~SOURCE
       for foo in bar do
         for baz in qux do
         end
@@ -367,7 +379,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_hash
-    assert_metadata :hash, <<~SOURCE
+    assert_metadata :hash,
+                    <<~SOURCE
       {
         foo: 'bar'
       }
@@ -375,7 +388,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_if
-    assert_metadata :if, <<~SOURCE
+    assert_metadata :if,
+                    <<~SOURCE
       if foo
         if bar; end
       end
@@ -399,13 +413,15 @@ class MetadataTest < Minitest::Test
   end
 
   def test_lambda
-    assert_metadata :lambda, <<~SOURCE
+    assert_metadata :lambda,
+                    <<~SOURCE
       -> (foo, bar) {
         foo + bar
       }
     SOURCE
 
-    assert_metadata :lambda, <<~SOURCE
+    assert_metadata :lambda,
+                    <<~SOURCE
       lambda do |foo, bar|
         foo + bar
       end
@@ -457,7 +473,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_module
-    assert_metadata :module, <<~SOURCE
+    assert_metadata :module,
+                    <<~SOURCE
       module Foo
         module Bar; end
       end
@@ -565,7 +582,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_sclass
-    assert_metadata :sclass, <<~SOURCE
+    assert_metadata :sclass,
+                    <<~SOURCE
       class << Foo
         class << Bar; end
       end
@@ -573,7 +591,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_string_concat
-    assert_metadata :string_concat, <<~SOURCE
+    assert_metadata :string_concat,
+                    <<~SOURCE
       'foo' \
         'bar'
     SOURCE
@@ -637,7 +656,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_unless
-    assert_metadata :unless, <<~SOURCE
+    assert_metadata :unless,
+                    <<~SOURCE
       unless foo
         unless bar; end
       end
@@ -649,7 +669,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_until
-    assert_metadata :until, <<~SOURCE
+    assert_metadata :until,
+                    <<~SOURCE
       until foo
         until bar; end
       end
@@ -661,7 +682,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_while
-    assert_metadata :while, <<~SOURCE
+    assert_metadata :while,
+                    <<~SOURCE
       while foo
         while bar; end
       end
@@ -713,7 +735,8 @@ class MetadataTest < Minitest::Test
   end
 
   def test_xstring
-    assert_metadata :xstring_literal, <<~SOURCE
+    assert_metadata :xstring_literal,
+                    <<~SOURCE
       `
         foo
         bar


### PR DESCRIPTION
## Purpose

Instead of ad-hoc code in various places plucking out heredoc `beging`, `contents`, and `ending` in order to print it more intelligently in certain cases, this changes the way heredocs are printed altogether so they can simply be printed in any context and still work correctly. This prevents heredocs appearing in various parts of the syntax tree from _absorbing_ other lines of code because they break after the heredoc literal and before the heredoc contents because they were manually plucked out the AST and inserted in the Doc contextually. 

fixes prettier/plugin-ruby#624
fixes prettier/plugin-ruby#586
fixes prettier/plugin-ruby#316
fixes prettier/plugin-ruby#301

## Approach

I used `lineSuffix`.

The heredoc is 3 components, `beging` (the token), `contents` (the initial content and ending newline), and `ending` (the token ending).

```ruby
<<-TEXT
stuff stuff
stuff
TEXT
```

`beging`=`<<-TEXT`
`contents`=`stuff stuff\nstuff\n`
`ending`=`TEXT`

#### lineSuffix

[There exists a command in prettier's set of builders called `lineSufix`](https://github.com/prettier/prettier/blob/master/commands.md#linesuffix). It's listed as used for implementing trailing comments. The doc contents you wrap in `lineSuffix()` are appended to the end of the line during printing. This seemed appropriate for this use case because of the following facts about heredocs:

1. A heredoc literal beging can appear anywhere and can be treated like a string literal. things can be chained to it, it may need a trailing comma, etc).

Conclusion: When printing a heredoc, more code should be able to print after the heredoc literal before the next line.

2. The next line break after the heredoc beging **is part of the heredoc contents. period.**

Conclusion: A line break must _always_ appear, after which the contents printed then the ending. Code can continue on the next line. 

Conclusion: Code chained or in the same expression as the heredoc beging must fit on the same line as the heredoc beging or be broken and continue on the newline after the ending.

3. Using `lineSuffix` when printing heredocs allows us to guarantee an append to the end of that line where we can insert a literalline (non-negotiable line break), the contents, and the ending. Code continues printing after this ending newline.

Conclusion: `lineSuffix`'s behavior matches the behavior of heredocs in general and would allow a heredoc to be printed correctly in any context. The heredoc print would look like this:

```js
concat([
  beging,
  lineSuffix(concat([literalline, concat(parts), ending]))
]);
```

In words: since a heredoc beging appears "here", print the beging "here", but guarantee the following contents will appear at the end of the "here" line: `linebreak, contents, ending`. 

#### Result:

Thus, the end of line break and next few lines are guaranteed to be the heredoc contents (no absorbing other lines), the beging is the only doc portion printed in place so trailing commas and method chaining works fine. At this point, _all heredocs are printing themselves correctly anywhere they appear in the AST/Doc. The code used to manually slice up the heredoc and print it correctly in various places (hash.js, array.js, calls.js, utils.js) could now be removed and everything would print valid ruby code.

#### Change in formatting for heredocs in most places

However, now that a lineSuffix with a literalline is appended to the line with the heredoc, the `literalline` seems to break the `group`s and all parent `group`s, resulting in broken-up expressions wherever a heredoc appears. Here's an example:

**Before these changes:**

This expression would stay the same before and after formatting:

```ruby
call(1, <<-TEXT.squish)
  a sentence
TEXT
```

**After these changes:**

```ruby
call(
  1,
  <<-TEXT.squish
  a sentence
TEXT
)
```

I suspect because we're adding a literalline in the linesuffix of a heredoc printed doc, the result is that all parent groups are broken and can no longer be printed on a single line.

My opinion is that this is not undesirable, products consistent heredocs everywhere with more vertical space and potentially less confusion with those less familiar with heredocs. For example, two heredocs on the same line would now print differently:

Input:

```ruby
command 1, 2, 3, <<-HERE, <<-THERE
  here
HERE
  there
THERE
```

Becomes:

```ruby
command 1,
        2,
        3,
        <<-HERE,
  here
HERE
        <<-THERE
  there
THERE
```

