### PR TITLE
Print heredocs consistently with lineSuffix(newline+contents+ending) II

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --cache .",
     "print": "prettier --plugin=.",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --cache .",
     "print": "prettier --plugin=.",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "repository": {
     "type": "git",

--- a/src/nodes/arrays.js
+++ b/src/nodes/arrays.js
@@ -5,7 +5,6 @@ const {
   indent,
   join,
   line,
-  literalline,
   softline
 } = require("../prettier");
 
@@ -114,40 +113,15 @@ module.exports = {
     const elementDocs = path.call(print, "body", 0);
     const elements = getElements(path.getValue().body[0], ["body", 0]);
 
-    // We need to manually loop through the elements in the array in order to
-    // take care of heredocs printing (their commas go after the opening, as
-    // opposed to at the end).
-    elements.forEach(({ element, elementPath }, index) => {
+    elements.forEach((_, index) => {
       const isInner = index !== elements.length - 1;
 
-      const isStraightHeredoc = element.type === "heredoc";
-      const isSquigglyHeredoc =
-        element.type === "string_literal" && element.body[0].type === "heredoc";
+      normalDocs.push(elementDocs[index]);
 
-      if (isStraightHeredoc || isSquigglyHeredoc) {
-        const heredocNode = isStraightHeredoc ? element : element.body[0];
-        const heredocPath = [print].concat(elementPath);
-
-        if (isSquigglyHeredoc) {
-          heredocPath.push("body", 0);
-        }
-
-        normalDocs.push(
-          heredocNode.beging,
-          isInner || addTrailingCommas ? "," : "",
-          literalline,
-          concat(path.map.apply(path, heredocPath.concat("body"))),
-          heredocNode.ending,
-          isInner ? line : ""
-        );
-      } else {
-        normalDocs.push(elementDocs[index]);
-
-        if (isInner) {
-          normalDocs.push(concat([",", line]));
-        } else if (addTrailingCommas) {
-          normalDocs.push(ifBreak(",", ""));
-        }
+      if (isInner) {
+        normalDocs.push(concat([",", line]));
+      } else if (addTrailingCommas) {
+        normalDocs.push(ifBreak(",", ""));
       }
     });
 

--- a/src/nodes/commands.js
+++ b/src/nodes/commands.js
@@ -1,5 +1,5 @@
 const { align, concat, group, ifBreak, join, line } = require("../prettier");
-const { docLength, makeArgs, makeCall } = require("../utils");
+const { docLength, makeCall } = require("../utils");
 
 const hasDef = (node) =>
   node.body[1].type === "args_add_block" &&
@@ -26,29 +26,18 @@ const skipArgsAlign = (path) =>
 module.exports = {
   command: (path, opts, print) => {
     const command = path.call(print, "body", 0);
-    const { args, heredocs } = makeArgs(path, opts, print, 1);
 
-    if (heredocs.length > 1) {
-      return concat([command, " ", join(", ", args)].concat(heredocs));
-    }
-
-    const joinedArgs = join(concat([",", line]), args);
+    const joinedArgs = join(concat([",", line]), path.call(print, "body", 1));
     const breakArgs = hasDef(path.getValue())
       ? joinedArgs
       : align(command.length + 1, joinedArgs);
 
-    const commandDoc = group(
+    return group(
       ifBreak(
         concat([command, " ", breakArgs]),
         concat([command, " ", joinedArgs])
       )
     );
-
-    if (heredocs.length === 1) {
-      return group(concat([commandDoc].concat(heredocs)));
-    }
-
-    return commandDoc;
   },
   command_call: (path, opts, print) => {
     const parts = [
@@ -62,25 +51,14 @@ module.exports = {
     }
 
     parts.push(" ");
-    const { args, heredocs } = makeArgs(path, opts, print, 3);
 
-    if (heredocs.length > 1) {
-      return concat(parts.concat([join(", ", args)]).concat(heredocs));
-    }
-
-    const joinedArgs = join(concat([",", line]), args);
+    const joinedArgs = join(concat([",", line]), path.call(print, "body", 3));
     const breakArgs = skipArgsAlign(path)
       ? joinedArgs
       : align(docLength(concat(parts)), joinedArgs);
 
-    const commandDoc = group(
+    return group(
       ifBreak(concat(parts.concat(breakArgs)), concat(parts.concat(joinedArgs)))
     );
-
-    if (heredocs.length === 1) {
-      return group(concat([commandDoc].concat(heredocs)));
-    }
-
-    return commandDoc;
   }
 };

--- a/src/nodes/hashes.js
+++ b/src/nodes/hashes.js
@@ -1,12 +1,4 @@
-const {
-  concat,
-  group,
-  ifBreak,
-  indent,
-  join,
-  line,
-  literalline
-} = require("../prettier");
+const { concat, group, ifBreak, indent, join, line } = require("../prettier");
 const { nodeDive, prefix, skipAssignIndent } = require("../utils");
 
 // When attempting to convert a hash rocket into a hash label, you need to take
@@ -77,43 +69,13 @@ module.exports = {
 
     assocNodes.forEach((assocNode, index) => {
       const isInner = index !== assocNodes.length - 1;
-      const valueNode = assocNode.body[1];
 
-      const isStraightHeredoc = valueNode && valueNode.type === "heredoc";
-      const isSquigglyHeredoc =
-        valueNode &&
-        valueNode.type === "string_literal" &&
-        valueNode.body[0].type === "heredoc";
+      assocDocs.push(path.call(print, "body", 0, index));
 
-      if (isStraightHeredoc || isSquigglyHeredoc) {
-        const heredocSteps = isStraightHeredoc
-          ? ["body", 1]
-          : ["body", 1, "body", 0];
-        const { beging, ending } = nodeDive(assocNode, heredocSteps);
-
-        assocDocs.push(
-          makeLabel(path, opts, print, ["body", 0, index, "body", 0]),
-          " ",
-          beging,
-          isInner || addTrailingCommas ? "," : "",
-          literalline,
-          concat(
-            path.map.apply(
-              path,
-              [print, "body", 0, index].concat(heredocSteps).concat("body")
-            )
-          ),
-          ending,
-          isInner ? line : ""
-        );
-      } else {
-        assocDocs.push(path.call(print, "body", 0, index));
-
-        if (isInner) {
-          assocDocs.push(concat([",", line]));
-        } else if (addTrailingCommas) {
-          assocDocs.push(ifBreak(",", ""));
-        }
+      if (isInner) {
+        assocDocs.push(concat([",", line]));
+      } else if (addTrailingCommas) {
+        assocDocs.push(ifBreak(",", ""));
       }
     });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,4 @@
-const {
-  breakParent,
-  concat,
-  hardline,
-  lineSuffix,
-  literalline
-} = require("./prettier");
+const { breakParent, concat, hardline, lineSuffix } = require("./prettier");
 
 const concatBody = (path, opts, print) => concat(path.map(print, "body"));
 
@@ -51,45 +45,6 @@ const hasAncestor = (path, types) => {
 };
 
 const literal = (value) => () => value;
-
-const makeArgs = (path, opts, print, argsIndex) => {
-  let argNodes = path.getValue().body[argsIndex];
-  const argPattern = [print, "body", argsIndex, "body"];
-
-  if (argNodes.type === "args_add_block") {
-    [argNodes] = argNodes.body;
-    argPattern.push(0, "body");
-  }
-
-  const args = path.call(print, "body", argsIndex);
-  const heredocs = [];
-
-  argNodes.body.forEach((argNode, index) => {
-    let pattern;
-    let heredoc;
-
-    if (argNode.type === "heredoc") {
-      pattern = [index, "body"];
-      heredoc = argNode;
-    } else if (
-      argNode.type === "string_literal" &&
-      argNode.body[0].type === "heredoc"
-    ) {
-      pattern = [index, "body", 0, "body"];
-      [heredoc] = argNode.body;
-    } else {
-      return;
-    }
-
-    const content = path.map.apply(path, argPattern.slice().concat(pattern));
-    heredocs.push(
-      concat([literalline].concat(content).concat([heredoc.ending]))
-    );
-    args[index] = heredoc.beging;
-  });
-
-  return { args, heredocs };
-};
 
 const makeCall = (path, opts, print) => {
   const operation = path.getValue().body[1];
@@ -149,6 +104,12 @@ const skipAssignIndent = (node) =>
 const surround = (left, right) => (path, opts, print) =>
   concat([left, path.call(print, "body", 0), right]);
 
+const literallineWithoutBreakParent = {
+  type: "line",
+  hard: true,
+  literal: true
+};
+
 module.exports = {
   concatBody,
   containsAssignment,
@@ -157,7 +118,7 @@ module.exports = {
   first,
   hasAncestor,
   literal,
-  makeArgs,
+  literallineWithoutBreakParent,
   makeCall,
   makeList,
   nodeDive,

--- a/test/js/args.test.js
+++ b/test/js/args.test.js
@@ -1,0 +1,228 @@
+const { ruby } = require("./utils");
+
+describe("args", () => {
+  describe("heredocs", () => {
+    test("#586 - long hash key after heredoc", () => {
+      const content = ruby(`
+        def foo(*); end
+
+        foo(
+          <<~FOO,
+            foo
+          FOO
+          named_argument_that_is_quite_long_so_it_doesnt_fit_on_one_line_with_the_heredoc: 'bar',
+        )
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          def foo(*); end
+
+          foo(
+            <<~FOO,
+              foo
+            FOO
+            named_argument_that_is_quite_long_so_it_doesnt_fit_on_one_line_with_the_heredoc:
+              'bar'
+          )
+        `)
+      );
+    });
+
+    test("#301 - heredoc arg w/ block", () => {
+      const content = ruby(`
+        puts(<<~TEXT
+          Hello
+        TEXT
+        ) { "sample block" }
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          puts(<<~TEXT) { 'sample block' }
+            Hello
+          TEXT
+        `)
+      );
+    });
+
+    test("#301 - in an activerecord scope arg w/ chaining", () => {
+      const content = ruby(`
+        scope :late_for_checkin, -> {
+          select(
+            <<-EOS.squish
+              devices.*, (
+                SELECT device_readings.id
+                FROM device_readings
+                WHERE device_readings.device_id = devices.id
+                  AND device_readings.taken_at > DATE_SUB(NOW(), INTERVAL (frequency * 2) MINUTE)
+                LIMIT 1
+              ) AS reading_id
+            EOS
+          )
+            .data_push
+            .having("reading_id IS NULL")
+        }
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          scope :late_for_checkin,
+                -> { select(<<-EOS.squish).data_push.having('reading_id IS NULL') }
+                devices.*, (
+                  SELECT device_readings.id
+                  FROM device_readings
+                  WHERE device_readings.device_id = devices.id
+                    AND device_readings.taken_at > DATE_SUB(NOW(), INTERVAL (frequency * 2) MINUTE)
+                  LIMIT 1
+                ) AS reading_id
+              EOS
+       `)
+      );
+    });
+
+    test("#586 - long breakable arg after heredoc literal", () => {
+      const content = ruby(`
+        p <<-BAR, ['value', 'value', 'value', 'value', 'value', 'value', 'value', 'value', 125484, 024024103]
+          text
+        BAR
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          p <<-BAR,
+            text
+          BAR
+            [
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              'value',
+              125_484,
+              0o24024103
+            ]
+        `)
+      );
+    });
+
+    test("#586 - call w/ short breakable arg after heredoc literal", () => {
+      const content = ruby(`
+        p(<<-BAR, ['value', 'value', 125_484, 0o24024103])
+          text
+        BAR
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("on calls", () => {
+      const content = ruby(`
+          call(1, 2, 3, <<-HERE) do
+           foo
+          HERE
+            puts 'more code'
+          end
+        `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          call(1, 2, 3, <<-HERE) { puts 'more code' }
+           foo
+          HERE
+        `)
+      );
+    });
+
+    test("on calls with trailing arguments", () => {
+      const content = ruby(`
+          call(1, <<-HERE, 2)
+            foo
+          HERE
+        `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("in parens args with trailing args after", () => {
+      const content = ruby(`
+          Foo.new(<<-ARG1, 'test2')
+            test1 line 1
+            test1 line 2
+          ARG1
+        `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("in paren args with a call", () => {
+      const content = ruby(`
+        Foo.new(<<~ARG1.upcase.chomp, 'test2')
+          test1 line 1
+          test1 line 2
+        ARG1
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("on calls with multiple", () => {
+      const content = ruby(`
+        call(1, 2, 3, <<-HERE, <<-THERE)
+          here
+        HERE
+          there
+        THERE
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("on commands", () => {
+      const content = ruby(`
+        command 1, 2, 3, <<-HERE
+          foo
+        HERE
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("on commands with multiple", () => {
+      const content = ruby(`
+          command 1, 2, 3, <<-HERE, <<-THERE
+            here
+          HERE
+            there
+          THERE
+        `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("on command calls with trailing arg", () => {
+      const content = ruby(`
+        command.call 1, 2, 3, <<-HERE, 4
+          foo
+        HERE
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("on command calls with multiple", () => {
+      const content = ruby(`
+        command.call 1, 2, 3, <<-HERE, <<-THERE
+          here
+        HERE
+            there
+        THERE
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+  });
+});

--- a/test/js/array.test.js
+++ b/test/js/array.test.js
@@ -91,7 +91,13 @@ describe("array", () => {
         ]
       `);
 
-      return expect(content).toMatchFormat();
+      return expect(content).toChangeFormat(
+        ruby(`
+          [${start}, foo]
+              this is the heredoc
+            HERE
+        `)
+      );
     });
 
     test("as the last value", () => {
@@ -104,7 +110,13 @@ describe("array", () => {
         ]
       `);
 
-      return expect(content).toMatchFormat();
+      return expect(content).toChangeFormat(
+        ruby(`
+          [foo, ${start}]
+              this is the heredoc
+            HERE
+        `)
+      );
     });
 
     test("with splats in the array", () => {
@@ -119,7 +131,13 @@ describe("array", () => {
         ]
       `);
 
-      return expect(content).toMatchFormat();
+      return expect(content).toChangeFormat(
+        ruby(`
+          [foo, *bar, baz, ${start}]
+              this is the heredoc
+            HERE
+        `)
+      );
     });
 
     test("with trailing commas", () => {
@@ -131,7 +149,13 @@ describe("array", () => {
         ]
       `);
 
-      return expect(content).toMatchFormat({ addTrailingCommas: true });
+      return expect(content).toChangeFormat(
+        ruby(`
+          [${start}]
+              this is the heredoc
+            HERE
+        `)
+      );
     });
   });
 });

--- a/test/js/assign.test.js
+++ b/test/js/assign.test.js
@@ -4,6 +4,16 @@ describe("assign", () => {
   describe("single assignment", () => {
     test("basic", () => expect("a = 1").toMatchFormat());
 
+    test("heredoc", () => {
+      const content = ruby(`
+        text = <<-TEXT
+          abcd
+        TEXT
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
     test("multiline", () => {
       const content = ruby(`
         a =

--- a/test/js/calls.test.js
+++ b/test/js/calls.test.js
@@ -1,0 +1,96 @@
+const { ruby } = require("./utils");
+
+describe("calls", () => {
+  describe("on heredocs", () => {
+    test("squiggly no indent", () => {
+      const content = ruby(`
+        foo = <<~TEXT.strip
+          bar
+        TEXT
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+
+    test("squiggly indent", () => {
+      const content = ruby(`
+        foo = (<<~TEXT
+          bar
+        TEXT
+        ).strip
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          foo = (<<~TEXT).strip
+            bar
+          TEXT
+        `)
+      );
+    });
+
+    test("straight no indent", () => {
+      const content = ruby(`
+        foo = <<-TEXT.strip
+        bar
+        TEXT
+      `);
+
+      return expect(content).toMatchFormat();
+    });
+  });
+
+  test("with a call and indented", () => {
+    const content = ruby(`
+      def foo
+        <<-HERE.strip
+          bar
+        HERE
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("with a method call", () => {
+    const content = ruby(`
+      <<-HERE.strip.chomp
+        This is a straight heredoc
+        with two method calls
+      HERE
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("with two calls and indented", () => {
+    const content = ruby(`
+      def foo
+        <<~HERE.strip.chomp
+          bar
+        HERE
+      end
+    `);
+
+    return expect(content).toMatchFormat();
+  });
+
+  test("with a long list of calls and line length", () => {
+    const content = ruby(`
+      <<~HERE.strip.chomp.split.concat(['one']).join.gsub(/one|two|three|four/, 'number').gsub('®', '').reverse
+        bar
+      HERE
+    `);
+
+    return expect(content).toChangeFormat(
+      ruby(`
+        <<~HERE.strip.chomp.split.concat(%w[one]).join.gsub(
+          bar
+        HERE
+          /one|two|three|four/,
+          'number'
+        ).gsub('®', '').reverse
+    `)
+    );
+  });
+});

--- a/test/js/hashes.test.js
+++ b/test/js/hashes.test.js
@@ -34,12 +34,9 @@ describe("hash", () => {
   describe.each(["<<-HERE", "<<~HERE"])("%s heredocs as values", (start) => {
     test("as the first value", () => {
       const content = ruby(`
-        {
-          foo: ${start},
+        { foo: ${start}, bar: 'bar' }
             this is the heredoc
           HERE
-          bar: 'bar'
-        }
       `);
 
       return expect(content).toMatchFormat();
@@ -47,12 +44,9 @@ describe("hash", () => {
 
     test("as the last value", () => {
       const content = ruby(`
-        {
-          foo: 'foo',
-          bar: ${start}
+        { foo: 'foo', bar: ${start} }
             this is the heredoc
           HERE
-        }
       `);
 
       return expect(content).toMatchFormat();
@@ -60,14 +54,35 @@ describe("hash", () => {
 
     test("with trailing commas", () => {
       const content = ruby(`
-        {
-          foo: ${start},
+        { foo: ${start} }
             this is the heredoc
           HERE
-        }
       `);
 
       return expect(content).toMatchFormat({ addTrailingCommas: true });
+    });
+
+    test("when exceeding line length", () => {
+      const content = ruby(`
+        { foo: 'foo', bar: <<-HERE, three: 'four', five: 'six', seven: 'eight', nine: 'ten' }
+          this is the heredoc
+        HERE
+      `);
+
+      return expect(content).toChangeFormat(
+        ruby(`
+          {
+            foo: 'foo',
+            bar: <<-HERE,
+            this is the heredoc
+          HERE
+            three: 'four',
+            five: 'six',
+            seven: 'eight',
+            nine: 'ten'
+          }
+        `)
+      );
     });
   });
 


### PR DESCRIPTION
## Purpose

Instead of ad-hoc code in various places plucking out heredoc `beging`, `contents`, and `ending` in order to print it more intelligently in certain cases, this changes the way heredocs are printed altogether so they can simply be printed in any context and still work correctly. This prevents heredocs appearing in various parts of the syntax tree from _absorbing_ other lines of code because they break after the heredoc literal and before the heredoc contents because they were manually plucked out the AST and inserted in the Doc contextually. 

fixes prettier/plugin-ruby#624
fixes prettier/plugin-ruby#586
fixes prettier/plugin-ruby#316
fixes prettier/plugin-ruby#301

## Approach

I used `lineSuffix`.

The heredoc is 3 components, `beging` (the token), `contents` (the initial content and ending newline), and `ending` (the token ending).

```ruby
<<-TEXT
stuff stuff
stuff
TEXT
```

`beging`=`<<-TEXT`
`contents`=`stuff stuff\nstuff\n`
`ending`=`TEXT`

#### lineSuffix

[There exists a command in prettier's set of builders called `lineSufix`](https://github.com/prettier/prettier/blob/master/commands.md#linesuffix). It's listed as used for implementing trailing comments. The doc contents you wrap in `lineSuffix()` are appended to the end of the line during printing. This seemed appropriate for this use case because of the following facts about heredocs:

1. A heredoc literal beging can appear anywhere and can be treated like a string literal. things can be chained to it, it may need a trailing comma, etc).

Conclusion: When printing a heredoc, more code should be able to print after the heredoc literal before the next line.

2. The next line break after the heredoc beging **is part of the heredoc contents. period.**

Conclusion: A line break must _always_ appear, after which the contents printed then the ending. Code can continue on the next line. 

Conclusion: Code chained or in the same expression as the heredoc beging must fit on the same line as the heredoc beging or be broken and continue on the newline after the ending.

3. Using `lineSuffix` when printing heredocs allows us to guarantee an append to the end of that line where we can insert a literalline (non-negotiable line break), the contents, and the ending. Code continues printing after this ending newline.

Conclusion: `lineSuffix`'s behavior matches the behavior of heredocs in general and would allow a heredoc to be printed correctly in any context. The heredoc print would look like this:

```js
concat([
  beging,
  lineSuffix(concat([literalline, concat(parts), ending]))
]);
```

In words: since a heredoc beging appears "here", print the beging "here", but guarantee the following contents will appear at the end of the "here" line: `linebreak, contents, ending`. 

#### Result:

Thus, the end of line break and next few lines are guaranteed to be the heredoc contents (no absorbing other lines), the beging is the only doc portion printed in place so trailing commas and method chaining works fine. At this point, _all heredocs are printing themselves correctly anywhere they appear in the AST/Doc. The code used to manually slice up the heredoc and print it correctly in various places (hash.js, array.js, calls.js, utils.js) could now be removed and everything would print valid ruby code.

All code handling heredocs manually is removed, lines don't always break, but they do if they have to.

Examples:

#### Calls w/ blocks

```js
    test("#301 - heredoc arg w/ block", () => {
      const content = ruby(`
        puts(<<~TEXT
          Hello
        TEXT
        ) { "sample block" }
      `);

      return expect(content).toChangeFormat(
        ruby(`
          puts(<<~TEXT) { 'sample block' }
            Hello
          TEXT
        `)
      );
    });
```

```js
    test("#301 - in an activerecord scope arg w/ chaining", () => {
      const content = ruby(`
        scope :late_for_checkin, -> {
          select(
            <<-EOS.squish
              devices.*, (
                SELECT device_readings.id
                FROM device_readings
                WHERE device_readings.device_id = devices.id
                  AND device_readings.taken_at > DATE_SUB(NOW(), INTERVAL (frequency * 2) MINUTE)
                LIMIT 1
              ) AS reading_id
            EOS
          )
            .data_push
            .having("reading_id IS NULL")
        }
      `);

      return expect(content).toChangeFormat(
        ruby(`
          scope :late_for_checkin,
                -> { select(<<-EOS.squish).data_push.having('reading_id IS NULL') }
                devices.*, (
                  SELECT device_readings.id
                  FROM device_readings
                  WHERE device_readings.device_id = devices.id
                    AND device_readings.taken_at > DATE_SUB(NOW(), INTERVAL (frequency * 2) MINUTE)
                  LIMIT 1
                ) AS reading_id
              EOS
       `)
      );
    });
```

#### In and around args

```js
    test("#586 - long breakable arg after heredoc literal", () => {
      const content = ruby(`
        p <<-BAR, ['value', 'value', 'value', 'value', 'value', 'value', 'value', 'value', 125484, 024024103]
          text
        BAR
      `);

      return expect(content).toChangeFormat(
        ruby(`
          p <<-BAR,
            text
          BAR
            [
              'value',
              'value',
              'value',
              'value',
              'value',
              'value',
              'value',
              'value',
              125_484,
              0o24024103
            ]
        `)
      );
    });
```

```js
    test("#586 - call w/ short breakable arg after heredoc literal", () => {
      const content = ruby(`
        p(<<-BAR, ['value', 'value', 125_484, 0o24024103])
          text
        BAR
      `);

      return expect(content).toMatchFormat();
    });
```

```js
    test("in paren args with a call", () => {
      const content = ruby(`
        Foo.new(<<~ARG1.upcase.chomp, 'test2')
          test1 line 1
          test1 line 2
        ARG1
      `);

      return expect(content).toMatchFormat();
    });
```

```js

    test("on command calls with multiple", () => {
      const content = ruby(`
        command.call 1, 2, 3, <<-HERE, <<-THERE
          here
        HERE
            there
        THERE
      `);

      return expect(content).toMatchFormat();
    });
```

```js
    test("squiggly indent", () => {
      const content = ruby(`
        foo = (<<~TEXT
          bar
        TEXT
        ).strip
      `);

      return expect(content).toChangeFormat(
        ruby(`
          foo = (<<~TEXT).strip
            bar
          TEXT
        `)
      );
    });
```

#### Hashes:

```js
    test("when exceeding line length", () => {
      const content = ruby(`
        { foo: 'foo', bar: <<-HERE, three: 'four', five: 'six', seven: 'eight', nine: 'ten' }
          this is the heredoc
        HERE
      `);

      return expect(content).toChangeFormat(
        ruby(`
          {
            foo: 'foo',
            bar: <<-HERE,
            this is the heredoc
          HERE
            three: 'four',
            five: 'six',
            seven: 'eight',
            nine: 'ten'
          }
        `)
      );
    });
```

#### Arrays

```js
    test("as the last value", () => {
      const content = ruby(`
        [
          foo,
          ${start}
            this is the heredoc
          HERE
        ]
      `);

      return expect(content).toChangeFormat(
        ruby(`
          [foo, ${start}]
              this is the heredoc
            HERE
        `)
      );
    });
```

I found this one particularly interesting:

### Nested heredocs

```js
      test("nested within another", () => {
        const content = ruby(`
          <<~PARENT
            This is a squiggly heredoc
            #{
            <<~CHILD
              This is an interpolated squiggly heredoc
              CHILD
          }
          PARENT
        `);

        return expect(content).toChangeFormat(
          ruby(`
            <<~PARENT
              This is a squiggly heredoc
              #{<<~CHILD}
                This is an interpolated squiggly heredoc
                CHILD
            PARENT
          `)
        );
      });
```

If you prefer this approach, let me know and I can update the PR.
