### PR TITLE
Always use lambda literal shorthand

### DIFF
--- a/test/js/lambda.test.js
+++ b/test/js/lambda.test.js
@@ -13,11 +13,11 @@ describe("lambda", () => {
     expect("-> () { 1 }").toChangeFormat("-> { 1 }"));
 
   test("breaking stabby lambda literal", () =>
-    expect(`-> { ${long} }`).toChangeFormat(`lambda do\n  ${long}\nend`));
+    expect(`-> { ${long} }`).toChangeFormat(`-> do\n  ${long}\nend`));
 
   test("breaking stabby lambda literal with args", () => {
     const content = `->(a) { a + ${long} }`;
-    const expected = `lambda do |a|\n  a +\n    ${long}\nend`;
+    const expected = `->(a) do\n  a +\n    ${long}\nend`;
 
     return expect(content).toChangeFormat(expected);
   });
@@ -29,7 +29,7 @@ describe("lambda", () => {
     expect(`command :foo, -> { ${long} }`).toChangeFormat(
       ruby(`
       command :foo,
-              lambda {
+              -> {
                 ${long}
               }
     `)
@@ -42,7 +42,7 @@ describe("lambda", () => {
     expect(`command.call :foo, -> { ${long} }`).toChangeFormat(
       ruby(`
       command.call :foo,
-                   lambda {
+                   -> {
                      ${long}
                    }
     `)
@@ -52,21 +52,35 @@ describe("lambda", () => {
     expect(`command :foo, bar: -> { ${long} }`).toChangeFormat(
       ruby(`
       command :foo,
-              bar: lambda {
+              bar: -> {
                 ${long}
               }
     `)
     ));
 
-  test("very long arguments list doesn't break within pipes", () => {
+  test("stabby lambda literal that breaks deeply within a command node", () =>
+    expect(
+      `command :named_scope, ->(true_or_false = !is_something?) { where(enabled_or_something: true_or_false) }`
+    ).toChangeFormat(
+      ruby(`
+      command :named_scope,
+              ->(true_or_false = !is_something?) {
+                where(enabled_or_something: true_or_false)
+              }
+      `)
+    ));
+
+  test("very long arguments list breaks", () => {
     const content = `command :foo, ->(${long}, a${long}, aa${long}) { true }`;
 
     return expect(content).toChangeFormat(
       ruby(`
       command :foo,
-              lambda { |${long}, a${long}, aa${long}|
-                true
-              }
+              ->(
+                ${long},
+                a${long},
+                aa${long}
+              ) { true }
     `)
     );
   });


### PR DESCRIPTION
https://github.com/prettier/plugin-ruby/issues/651

## Metadata

* Ruby version: 2.6
* @prettier/plugin-ruby version: 0.20.1

## Input

```ruby
  scope :sandbox, ->(true_or_false = !Rails.env.production?) { where(sandbox: true_or_false) }
```

## Before this PR

```ruby
  scope :sandbox,
        lambda { |true_or_false = !Rails.env.production?|
          where(sandbox: true_or_false)
        }
```

## After this PR

```ruby
  scope :sandbox,
        ->(true_or_false = !Rails.env.production?) {
          where(sandbox: true_or_false)
        }
```

## Reasoning

The current output is invalid ruby syntax. I did my best to read through the ruby grammar (`parse.y`) and determine why a unary (`!`) would be valid in `->(...)`, but not in `do |...|` and I was grasping at straws a bit. I'm not experienced enough with the grammar there to determine if there's a bug in the parser and it's picking the wrong matcher for args in `do |...|` where a unary isn't allowed, but nonetheless it breaks.

Example:

```ruby
>> ->(active = !dead?) { '' }
=> #<Proc:0x00007f968403ac10@(irb):1 (lambda)>
```

```ruby
>> lambda { |active = !dead?| '' }
Traceback (most recent call last):
        3: from /Users/jbielick/.rubies/ruby-2.6.6/bin/irb:23:in `<main>'
        2: from /Users/jbielick/.rubies/ruby-2.6.6/bin/irb:23:in `load'
        1: from /Users/jbielick/.rubies/ruby-2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
SyntaxError ((irb):2: syntax error, unexpected '!')
lambda { |active = !dead?| '' }
                   ^
(irb):2: syntax error, unexpected '}', expecting end-of-input
lambda { |active = !dead?| '' }
```

Without determining exactly what the parsing grammar allow and disallows, I found it difficult to propose a change that would conditionally use `->` vs. `lambda {` when a particular arg pattern was detected. It was my assumption that _detection_ of _exceptions_ where `->` _must_ be used was futile. As a result, I think the best course of action is to use `->` for everything, since the args patterns it allows are a _superset_ of `do |...|` (block params) and it is likely unsafe to transform a `->(...)` into `lambda { |...|`.

## Results

Before:

```ruby
->(v = !n) { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }

lambda { |v = n.chomp| '' }

->(one: !n, looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongboi: 'yes') { 'aaaaaaa' }

puts ->(one: !!'two') { puts one && 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }

```

After:

```ruby
->(v = !n) do
  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
end

->(v = n.chomp) { '' }

->(
  one: !n,
  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongboi: 'yes'
) do 'aaaaaaa' end

puts ->(one: !!'two') {
       puts one &&
              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     }

```