### PR TITLE
maintain parser order during if/unless modifier

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,9 +4,13 @@ const concatBody = (path, opts, print) => concat(path.map(print, "body"));
 
 // If the node is a type of assignment or if the node is a paren and nested
 // inside that paren is a node that is a type of assignment.
-const containsAssignment = (node) =>
-  ["assign", "massign"].includes(node.type) ||
-  (node.type === "paren" && node.body[0].body.some(containsAssignment));
+const containsAssignment = (node) => {
+  return (
+    node &&
+    (["assign", "massign", "opassign"].includes(node.type) ||
+      (Array.isArray(node.body) && node.body.some(containsAssignment)))
+  );
+};
 
 const docLength = (doc) => {
   if (doc.length) {

--- a/test/js/conditionals.test.js
+++ b/test/js/conditionals.test.js
@@ -23,6 +23,53 @@ describe("conditionals", () => {
     });
   });
 
+  describe("modifiers", () => {
+    describe.each(["if", "unless"])("%s keyword", (keyword) => {
+      describe("when modifying an assignment expression", () => {
+        test("#591", () => {
+          const content = ruby(`
+            text = '${long}' ${keyword} text
+          `);
+          return expect(content).toChangeFormat(
+            ruby(`
+              text =
+                '${long}' ${keyword} text
+            `)
+          );
+        });
+      });
+      describe("when modifying an abbreviated assignment expression", () => {
+        test("#591", () => {
+          const content = ruby(`
+            text ||= '${long}' ${keyword} text
+          `);
+          return expect(content).toChangeFormat(
+            ruby(`
+              text ||=
+                '${long}' ${keyword} text
+            `)
+          );
+        });
+      });
+      describe("when modifying an expression with an assignment descendant", () => {
+        test("#591", () => {
+          const content = ruby(`
+            true && (text = '${long}') ${keyword} text
+          `);
+          return expect(content).toChangeFormat(
+            ruby(`
+              true &&
+                (
+                  text =
+                    '${long}'
+                ) ${keyword} text
+            `)
+          );
+        });
+      });
+    });
+  });
+
   describe("when inline allowed", () => {
     describe.each(["if", "unless"])("%s keyword", (keyword) => {
       test("inline stays", () => expect(`1 ${keyword} a`).toMatchFormat());
@@ -85,6 +132,18 @@ describe("conditionals", () => {
         const content = ruby(`
           array.each do |element|
             ${keyword} index = difference.index(element)
+              difference.delete_at(index)
+            end
+          end
+        `);
+
+        return expect(content).toMatchFormat();
+      });
+
+      test("breaks if the predicate is an op assignment", () => {
+        const content = ruby(`
+          array.each do |element|
+            ${keyword} index ||= difference.index(element)
               difference.delete_at(index)
             end
           end

--- a/test/js/parser.rb
+++ b/test/js/parser.rb
@@ -10,7 +10,9 @@ def gather
   return unless select([$stdin], nil, nil, 2)
 
   lines, line = [], nil
-  lines << line while (line = gets) != "---\n"
+  while (line = gets) != "---\n"
+    lines << line
+  end
   lines.join
 end
 


### PR DESCRIPTION
## Purpose

fixes prettier/plugin-ruby#591

### Input

Given the following snippet:

```
text = 'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong' if text
# => nil
```
   
[`text =` is parsed before `if text`](). 

### Current Output

The current formatting before this commit produces:

```ruby
if text
  text = 'loooo...ng'
end
# => NameError (undefined local variable or method `text' for main:Object)
```

The formatting is based on the fact that the expression exceeds a line limit, so it breaks and uses the if..end form. This has a nasty side effect in that text is not initialized before it's referenced and produces a NameError.

### New Output

Because the body of the conditional contains an assignment, we know that the parser would initialize this variable first and we need to retain that behavior or we may cause a NameError at runtime. Thus, here is the new output:

```ruby
text = 
  'loooo...ng' if text
```

## Approach

Search for any assignments in the `then` expression. If there are any, use the inline form of the conditional.

I updated `containsAssignment` to look recursively through the children for an assignment, since it's not guaranteed that it will be just a child or grandchild. 

```js
        test("#591", () => {
          const content = ruby(`
            text = '${long}' ${keyword} text
          `);
          return expect(content).toChangeFormat(
            ruby(`
              text =
                '${long}' ${keyword} text
            `)
          );
        });
      });
```

This change will also affect another place `containsAssignment` is used where detecting assignment in the predicate of a conditional expression. I think it has a positive effect there as well.

```js
      test("breaks if the predicate is an op assignment", () => {
        const content = ruby(`
          array.each do |element|
            ${keyword} index ||= difference.index(element)
              difference.delete_at(index)
            end
          end
        `);

        return expect(content).toMatchFormat();
      });
```